### PR TITLE
initial GA workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,6 +18,8 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: newrelic/nri-statsd
           tags: latest
+          # tags the image using either the branch,lastest (if master) or the tag
+          # since we are only triggering when a release is done, it shoudl only publish with the tag + latest
           tag_with_ref: true
 
 


### PR DESCRIPTION
Docker credentials added in the repo manually: settings/secrets