### PR TITLE
Fix default tags becoming mangled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ ARG GOSTATSD_TAG=34.2.1
 FROM atlassianlabs/gostatsd:$GOSTATSD_TAG
 
 COPY ./nri-statsd.sh .
+COPY ./run-statsd.sh .
 
 ENTRYPOINT ["/nri-statsd.sh"]

--- a/run-statsd.sh
+++ b/run-statsd.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/gostatsd --hostname ${HOSTNAME} --default-tags "hostname:${HOSTNAME} ${TAGS}" --config-path $NR_STATSD_CFG


### PR DESCRIPTION
Updated the way the service is run to fix issue with default tags becoming mangled - we were seeing that the tags were being read in as `"hostname:...` and anything following this was dropped, and I suspect it was the way the quotes were being handled/escaped.