### PR TITLE
Nr 341878 use reusable workflow for docker image security checks

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,34 +5,28 @@ on:
   push:
     branches:
       - master
-
-env:
-  TEST_IMAGE: "newrelic/nri-statsd:nightly"
-  DOCKER_IMAGE_TAG: "nightly"
+    paths:
+      - '.github/workflows/nightly.yml'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Reason for manual trigger'
+        required: false
+        type: string
 
 jobs:
-  trivy_scanner:
-    name: Security scanner for docker image
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
-          password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
-
-      - name: Build image
-        run: |
-          make build/docker-amd64 DOCKER_IMAGE_TAG=${{ env.DOCKER_IMAGE_TAG }}
-
-      - name: Run Trivy to check Docker image for vulnerabilities
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ env.TEST_IMAGE }}
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: "CRITICAL,HIGH"
+  nightly:
+    uses: newrelic/coreint-automation/.github/workflows/reusable_nightly.yaml@NR-341878-Use-reusable-workflow-for-docker-image-security-checks
+    secrets:
+      docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+      docker_password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
+    with:
+      docker_image: newrelic/nri-statsd
+      docker_tag: nightly
+      target_branches: "master"
+      build_command: |
+        make build/docker-amd64 DOCKER_IMAGE_TAG=nightly
+      setup_qemu: false
+      setup_buildx: false
+      setup_go: false
+      trivy_scan: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   nightly:
-    uses: newrelic/coreint-automation/.github/workflows/reusable_nightly.yaml@NR-341878-Use-reusable-workflow-for-docker-image-security-checks
+    uses: newrelic/coreint-automation/.github/workflows/reusable_nightly.yaml@v3
     secrets:
       docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
       docker_password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       reason:
-        description: 'Reason for manual trigger'
+        description: 'Manual Trigger To Test The Workflow'
         required: false
         type: string
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - '.github/workflows/nightly.yml'
   workflow_dispatch:
     inputs:
       reason:

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -54,19 +54,3 @@ jobs:
       - name: Running integration tests
         run: |
           make integration-tests-${{ matrix.arch }}
-  
-  testing-nightly:
-    uses: newrelic/coreint-automation/.github/workflows/reusable_nightly.yaml@NR-341878-Use-reusable-workflow-for-docker-image-security-checks
-    secrets:
-      docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
-      docker_password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
-    with:
-      docker_image: newrelic/nri-statsd
-      docker_tag: nightly
-      target_branches: "master"
-      build_command: |
-        make build/docker-amd64 DOCKER_IMAGE_TAG=nightly
-      setup_qemu: false
-      setup_buildx: false
-      setup_go: false
-      trivy_scan: true

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -11,22 +11,6 @@ on:
 
 jobs:
 
-  testing-nightly:
-    uses: newrelic/coreint-automation/.github/workflows/reusable_nightly.yaml@NR-341878-Use-reusable-workflow-for-docker-image-security-checks
-    secrets:
-      docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
-      docker_password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
-    with:
-      docker_image: newrelic/nri-statsd
-      docker_tag: nightly
-      target_branches: "master"
-      build_command: |
-        make build/docker-amd64 DOCKER_IMAGE_TAG=nightly
-      setup_qemu: false
-      setup_buildx: false
-      setup_go: false
-      trivy_scan: true
-
   static-analysis:
     name: Run static analysis checks
     runs-on: ubuntu-latest
@@ -70,3 +54,19 @@ jobs:
       - name: Running integration tests
         run: |
           make integration-tests-${{ matrix.arch }}
+  
+  testing-nightly:
+    uses: newrelic/coreint-automation/.github/workflows/reusable_nightly.yaml@NR-341878-Use-reusable-workflow-for-docker-image-security-checks
+    secrets:
+      docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+      docker_password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
+    with:
+      docker_image: newrelic/nri-statsd
+      docker_tag: nightly
+      target_branches: "master"
+      build_command: |
+        make build/docker-amd64 DOCKER_IMAGE_TAG=nightly
+      setup_qemu: false
+      setup_buildx: false
+      setup_go: false
+      trivy_scan: true

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -54,3 +54,19 @@ jobs:
       - name: Running integration tests
         run: |
           make integration-tests-${{ matrix.arch }}
+  
+  testing-nightly:
+    uses: newrelic/coreint-automation/.github/workflows/reusable_nightly.yaml@NR-341878-Use-reusable-workflow-for-docker-image-security-checks
+    secrets:
+      docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+      docker_password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
+    with:
+      docker_image: newrelic/nri-statsd
+      docker_tag: nightly
+      target_branches: "master"
+      build_command: |
+        make build/docker-amd64 DOCKER_IMAGE_TAG=nightly
+      setup_qemu: false
+      setup_buildx: false
+      setup_go: false
+      trivy_scan: true

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -11,6 +11,22 @@ on:
 
 jobs:
 
+  testing-nightly:
+    uses: newrelic/coreint-automation/.github/workflows/reusable_nightly.yaml@NR-341878-Use-reusable-workflow-for-docker-image-security-checks
+    secrets:
+      docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+      docker_password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
+    with:
+      docker_image: newrelic/nri-statsd
+      docker_tag: nightly
+      target_branches: "master"
+      build_command: |
+        make build/docker-amd64 DOCKER_IMAGE_TAG=nightly
+      setup_qemu: false
+      setup_buildx: false
+      setup_go: false
+      trivy_scan: true
+
   static-analysis:
     name: Run static analysis checks
     runs-on: ubuntu-latest
@@ -54,19 +70,3 @@ jobs:
       - name: Running integration tests
         run: |
           make integration-tests-${{ matrix.arch }}
-  
-  testing-nightly:
-    uses: newrelic/coreint-automation/.github/workflows/reusable_nightly.yaml@NR-341878-Use-reusable-workflow-for-docker-image-security-checks
-    secrets:
-      docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
-      docker_password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
-    with:
-      docker_image: newrelic/nri-statsd
-      docker_tag: nightly
-      target_branches: "master"
-      build_command: |
-        make build/docker-amd64 DOCKER_IMAGE_TAG=nightly
-      setup_qemu: false
-      setup_buildx: false
-      setup_go: false
-      trivy_scan: true


### PR DESCRIPTION
Initially creating a draft PR to test the reusable nightly workflow.
Will later modify everything once PRs get merged.