### PR TITLE
Moved to reuable release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,9 @@ jobs:
     with:
       original_repo_name: "newrelic/nri-statsd"
       docker_image_name: "newrelic/nri-statsd"
-
-      # docker_platforms: "linux/amd64,linux/arm64"
+      
+      # Cannot use default: base image does not support arm/v7
+      docker_platforms: "linux/amd64,linux/arm64"
 
       go_version_file: "tests/integration/go.mod"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   container-release:
-    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3
     with:
       original_repo_name: "newrelic/nri-statsd"
       docker_platforms: "linux/amd64,linux/arm64"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,21 +8,27 @@ on:
 
 jobs:
   container-release:
-    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
     with:
       original_repo_name: "newrelic/nri-statsd"
-      docker_platforms: "linux/amd64,linux/arm64"
       docker_image_name: "newrelic/nri-statsd"
-      go_version_file: "tests/integration/go.mod"
-      
-      run_integration_tests: true
-      run_nix_unit_tests: false
-      run_windows_unit_tests: false
-      
-      use_build_push_action: true
 
-      use_custom_release: false
-      release_command: "echo 'No custom release command'"
+      docker_platforms: "linux/amd64,linux/arm64"
+
+      go_version_file: "tests/integration/go.mod"
+
+      run_integration_tests: true
+      
+      release_command_sh: |
+        docker buildx build --push --platform=$DOCKER_PLATFORMS \
+          -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
+          .
+        if [[ "${{ github.event.release.prerelease }}" == "false" ]]; then
+          DOCKER_IMAGE_TAG=latest
+          docker buildx build --push --platform=$DOCKER_PLATFORMS \
+            -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
+            .
+        fi
 
     secrets:
       docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   container-release:
-    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@v3
     with:
       original_repo_name: "newrelic/nri-statsd"
       docker_image_name: "newrelic/nri-statsd"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       original_repo_name: "newrelic/nri-statsd"
       docker_image_name: "newrelic/nri-statsd"
 
-      docker_platforms: "linux/amd64,linux/arm64"
+      # docker_platforms: "linux/amd64,linux/arm64"
 
       go_version_file: "tests/integration/go.mod"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,123 +6,25 @@ on:
       - prereleased
       - released
 
-env:
-    ORIGINAL_REPO_NAME: "newrelic/nri-statsd"
-    DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
-    DOCKER_IMAGE_NAME: newrelic/nri-statsd
-    TAG: ${{ github.event.release.tag_name }}
-    VERSION: ""
-    TAG_SUFFIX: ""
-
 jobs:
-  integration-tests:
-    name: 🚧 integration tests
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: [  arm64, amd64 ]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
-          password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
-
-      - name: Running integration tests
-        run: |
-          make integration-tests-${{ matrix.arch }}
-
-  release-integration:
-    name: Publish container images to registry
-    runs-on: ubuntu-latest
-    needs: [integration-tests]
-    steps:
-        - name: Checkout master
-          uses: actions/checkout@v4
-
-        - name: Add pre-release tag suffix
-          if: ${{ github.event.release.prerelease }}
-          run: |
-            echo "TAG_SUFFIX=-pre" >> $GITHUB_ENV
-        
-        - name: Generate version from tag
-          run: |
-            TAG_WITHOUT_V=$(echo "${{ env.TAG }}" | sed 's/^v//')
-            echo "VERSION=$TAG_WITHOUT_V" >> $GITHUB_ENV
-        
-        - name: Set up QEMU
-          uses: docker/setup-qemu-action@v3
-        
-        - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v3
-        
-        - name: Login to DockerHub
-          uses: docker/login-action@v3
-          with:
-            username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
-            password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
-        
-        - name: Build and push docker image
-          uses: docker/build-push-action@v6
-          with:
-            platforms: ${{ env.DOCKER_PLATFORMS }}
-            context: .
-            push: true
-            tags: |
-              ${{ env.DOCKER_IMAGE_NAME }}:${{ env.VERSION }}${{ env.TAG_SUFFIX }}
-        
-        - name: Push latest tag
-          if: ${{ ! github.event.release.prerelease }}
-          uses: docker/build-push-action@v5
-          with:
-            platforms: ${{ env.DOCKER_PLATFORMS }}
-            context: .
-            push: true
-            tags: ${{ env.DOCKER_IMAGE_NAME }}:latest
-        
-        - name: Update title for successful pre-release
-          if: ${{ github.event.release.prerelease }}
-          env:
-            GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
-          run: |
-            gh release edit ${{ env.TAG }} --title "${{ env.TAG }}"
-
-  notify-failure:
-    if: ${{ always() && failure() }}
-    needs: [release-integration]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Notify failure via Slack
-        uses: archive/github-actions-slack@master
-        with:
-          slack-bot-user-oauth-access-token: ${{ secrets.COREINT_SLACK_TOKEN }}
-          slack-channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
-          slack-text: "❌ `${{ env.ORIGINAL_REPO_NAME }}`: [image release failed](${{ github.server_url }}/${{ env.ORIGINAL_REPO_NAME }}/actions/runs/${{ github.run_id }})."
-
-  update-title-on-failure:
-    if: ${{ always() && failure() }}
-    needs: [release-integration]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+  container-release:
+    uses: newrelic/coreint-automation/.github/workflows/reusable_image_release.yaml@NR-341876-Make-docker-images-pre-release-uniform
+    with:
+      original_repo_name: "newrelic/nri-statsd"
+      docker_platforms: "linux/amd64,linux/arm64"
+      docker_image_name: "newrelic/nri-statsd"
+      go_version_file: "tests/integration/go.mod"
       
-      - if: ${{ github.event.release.prerelease }}
-        name: Reflect failure in pre-release title
-        env:
-          GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
-        run: |
-          gh release edit ${{ github.event.release.tag_name }} --title "${{ github.event.release.tag_name }} (pre-release-failure)"
+      run_integration_tests: true
+      run_nix_unit_tests: false
+      run_windows_unit_tests: false
       
-      - if: ${{ ! github.event.release.prerelease }}
-        name: Reflect failure in release title
-        env:
-          GH_TOKEN: "${{ secrets.COREINT_BOT_TOKEN }}"
-        run: |
-          gh release edit ${{ github.event.release.tag_name }} --title "${{ github.event.release.tag_name }} (release-failure)"
+      use_build_push_action: true
+
+      use_custom_release: false
+      release_command: "echo 'No custom release command'"
+
+    secrets:
+      docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
+      docker_password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
+      bot_token: ${{ secrets.COREINT_BOT_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,6 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
-### dependencies
-- Updated crypto library to 0.31.0
-
-### enhancements
-- Moved nightlies and release process to reusable workflows
-
 ## v2.10.0 - 2024-12-11
 
 ### dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Unreleased section should follow [Release Toolkit](https://github.com/newrelic/r
 
 ## Unreleased
 
+### dependencies
+- Updated crypto library to 0.31.0
+
+### enhancements
+- Moved nightlies and release process to reusable workflows
+
 ## v2.10.0 - 2024-12-11
 
 ### dependencies


### PR DESCRIPTION
Tested the reusable workflow for pre releases.
This PR depends on https://github.com/newrelic/coreint-automation/pull/103
Merge that and then point the job to the correct branch before merging