### PR TITLE
Added exports and slack token and channel

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,12 +18,15 @@ jobs:
     secrets:
       docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
       docker_password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
+      slack_channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+      slack_token: ${{ secrets.COREINT_SLACK_TOKEN }}
     with:
       docker_image: newrelic/nri-statsd
       docker_tag: nightly
       target_branches: "master"
       build_command: |
-        make build/docker-amd64 DOCKER_IMAGE_TAG=nightly
+        export DOCKER_IMAGE_TAG=nightly
+        make build/docker-amd64
       setup_qemu: false
       setup_buildx: false
       setup_go: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
           .
         if [[ "${{ github.event.release.prerelease }}" == "false" ]]; then
-          DOCKER_IMAGE_TAG=latest
+          export DOCKER_IMAGE_TAG=latest
           docker buildx build --push --platform=$DOCKER_PLATFORMS \
             -t $DOCKER_IMAGE_NAME:$DOCKER_IMAGE_TAG \
             .
@@ -35,3 +35,5 @@ jobs:
       docker_username: ${{ secrets.OHAI_DOCKER_HUB_ID }}
       docker_password: ${{ secrets.OHAI_DOCKER_HUB_PASSWORD }}
       bot_token: ${{ secrets.COREINT_BOT_TOKEN }}
+      slack_channel: ${{ secrets.COREINT_SLACK_CHANNEL }}
+      slack_token: ${{ secrets.COREINT_SLACK_TOKEN }}


### PR DESCRIPTION
Added exports before setting variables in the automated release workflow shell commands.

Pass slack channel and and slack token as secrets to the reusable nightly and image release workflows.